### PR TITLE
feat(circuitbreaker): [N/A] 서킷 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,8 +3,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 plugins {
     id("org.springframework.boot") version "2.6.0"
     id("io.spring.dependency-management") version "1.0.11.RELEASE"
-    kotlin("jvm") version "1.6.0"
-    kotlin("plugin.spring") version "1.6.0"
+    kotlin("jvm") version "1.5.0"
+    kotlin("plugin.spring") version "1.5.0"
 }
 
 group = "com.example"
@@ -22,6 +22,13 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+
+    implementation("io.github.resilience4j:resilience4j-spring-boot2:1.5.0")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.boot:spring-boot-starter-aop")
+
+    implementation("io.github.resilience4j:resilience4j-micrometer:1.5.0")
+
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/com/example/springbootplayground/CircuitTestController.kt
+++ b/src/main/kotlin/com/example/springbootplayground/CircuitTestController.kt
@@ -1,0 +1,30 @@
+package com.example.springbootplayground
+
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class CircuitTestController(
+    val circuitTestService: CircuitTestService
+) {
+    @GetMapping("/count/success")
+    fun countSuccess(): String {
+        return circuitTestService.countSuccess()
+    }
+
+    @GetMapping("/count/error")
+    fun countError(): String {
+        return circuitTestService.countError()
+    }
+
+    @GetMapping("/time/success")
+    fun timeSuccess(): String {
+        return circuitTestService.timeSuccess()
+    }
+
+    @GetMapping("/time/error")
+    fun timeError(): String {
+        return circuitTestService.timeError()
+    }
+}

--- a/src/main/kotlin/com/example/springbootplayground/CircuitTestService.kt
+++ b/src/main/kotlin/com/example/springbootplayground/CircuitTestService.kt
@@ -1,0 +1,36 @@
+package com.example.springbootplayground
+
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestTemplate
+
+
+@Service
+class CircuitTestService(val testRestTemplate: RestTemplate) {
+
+    @CircuitBreaker(name="backendA", fallbackMethod = "fallback")
+    fun countSuccess(): String {
+        return "countSuccess"
+    }
+
+    @CircuitBreaker(name="backendA", fallbackMethod = "fallback")
+    fun countError(): String {
+        val a: String? = testRestTemplate.getForObject("http://localhost:8081", String::class.java)
+        return a!!
+    }
+
+    @CircuitBreaker(name="backendB", fallbackMethod = "fallback")
+    fun timeSuccess(): String {
+        return "timeSuccess"
+    }
+
+    @CircuitBreaker(name="backendB", fallbackMethod = "fallback")
+    fun timeError(): String {
+        val a: String? = testRestTemplate.getForObject("http://localhost:8081", String::class.java)
+        return a!!
+    }
+
+    fun fallback(ex: Exception):String {
+        return "fallback"
+    }
+}

--- a/src/main/kotlin/com/example/springbootplayground/config/RestTemplateConfig.kt
+++ b/src/main/kotlin/com/example/springbootplayground/config/RestTemplateConfig.kt
@@ -1,0 +1,15 @@
+package com.example.springbootplayground.config
+
+import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.client.RestTemplate
+
+@Configuration
+class RestTemplateConfig {
+
+    @Bean
+    fun testRestTemplate(builder: RestTemplateBuilder): RestTemplate {
+        return builder.build()
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,4 +2,19 @@ management:
   endpoints:
     web:
       exposure:
-        include: prometheus
+        include: '*'
+resilience4j:
+  circuitbreaker:
+    instances:
+      backendA:
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: 5
+        failureRateThreshold: 80
+        permittedNumberOfCallsInHalfOpenState: 3
+        waitDurationInOpenState: 10000
+      backendB:
+        slidingWindowType: TIME_BASED
+        slidingWindowSize: 50
+        failureRateThreshold: 80
+        waitDurationInOpenState: 10000
+        minimumNumberOfCalls: 10


### PR DESCRIPTION
[Resilience4j - CircuitBreaker](https://resilience4j.readme.io/docs/circuitbreaker)

### 목적
장애 전파를 막기 위함. (latency)

### 동작 원리
서킷의 상태 별로 살펴보자.

1. **closed(평시) -> open**

성공 / 실패를 판단한 뒤(4xx, 5xx은 실패처리) 결과를 ringbuffer에 저장. **특정 시점**에 ringbuffer에 저장된 요소로 실패율을 계산하여 threshold 이상이면 서킷 오픈. 서킷이 오픈된 동안에는 무조건 fallback 함수의 결과를 내보낸다. 

특정 시점이란?
COUNT_BASED: ringbuffer size가 slidingWindowSize에 도달하였을 때.
TIME_BASED: slidingWindowSize만큼 시간이 지나고, ringbuffer에 저장된 성공 / 실패 결과의 수가 minimumNumberOfCalls 이상일 때.

2. **open -> half_open**
open 상태 진입 뒤 waitDurationInOpenState 만큼의 시간이 지나면 ringbuffer 초기화 뒤 half_open state로 진입한다.

3. **half_open -> open**
permittedNumberOfCallsInHalfOpenState 만큼의 Request를 보내 실패율을 구한 뒤 threshold와 비교한다.
실패율이 threshold 이상이면 open 상태로 진입.

4. **half_open -> closed** 
permittedNumberOfCallsInHalfOpenState 만큼의 Request를 보내 실패율을 구한 뒤 threshold와 비교한다.
실패율이 threshold 미만이면 closed 상태로 진입.

